### PR TITLE
Add groupBy and associateBy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * `SingletonTable` class to handle more efficiently tables with only one entry
 * `EmptyTable` singleton to handle more efficiently empty tables
 * `toTable()` extension function on `Collection<Table.Entry<*, *, *>>` and `Map<Pair<*, *>, *>`
+* Ability to create tables from collections with `Collection.groupTableBy` and `Collection.associateTableBy`
 
 ### Changed
 * Now `tableOf()` return an instance of `SingletonTable` or `EmptyTable` if possible

--- a/src/main/kotlin/kable/Collections.kt
+++ b/src/main/kotlin/kable/Collections.kt
@@ -4,3 +4,9 @@ import kable.Table.Entry
 
 /** Create a new table with this entries */
 fun <R, C, V> Collection<Entry<R, C, V>>.toTable(): Table<R, C, V> = tableOf(this)
+
+inline fun <R, C, T> Collection<T>.groupTableBy(keySelector: (T) -> Pair<R, C>): Table<R, C, List<T>> =
+        groupBy(keySelector).toTable()
+
+inline fun <R, C, V, T> Collection<T>.groupTableBy(keySelector: (T) -> Pair<R, C>, valueTransform: (T) -> V): Table<R, C, List<V>> =
+        groupBy(keySelector, valueTransform).toTable()

--- a/src/main/kotlin/kable/Collections.kt
+++ b/src/main/kotlin/kable/Collections.kt
@@ -5,8 +5,49 @@ import kable.Table.Entry
 /** Create a new table with this entries */
 fun <R, C, V> Collection<Entry<R, C, V>>.toTable(): Table<R, C, V> = tableOf(this)
 
+/**
+ * Groups elements of the original collection by the key returned by the given [keySelector] function
+ * applied to each element and returns a [Table] where each group key is associated with a list of corresponding elements.
+ *
+ * The returned table preserves the entry iteration order of the keys produced from the original collection.
+ */
 inline fun <R, C, T> Collection<T>.groupTableBy(keySelector: (T) -> Pair<R, C>): Table<R, C, List<T>> =
         groupBy(keySelector).toTable()
 
+/**
+ * Groups values returned by the [valueTransform] function applied to each element of the original collection
+ * by the key returned by the given [keySelector] function applied to the element
+ * and returns a [Table] where each group key is associated with a list of corresponding values.
+ *
+ * The returned table preserves the entry iteration order of the keys produced from the original collection.
+ */
 inline fun <R, C, V, T> Collection<T>.groupTableBy(keySelector: (T) -> Pair<R, C>, valueTransform: (T) -> V): Table<R, C, List<V>> =
         groupBy(keySelector, valueTransform).toTable()
+
+/**
+ * Returns a [Table] containing key-value pairs provided by [transform] function
+ * applied to elements of the given collection.
+ *
+ * If any of two pairs would have the same key the last one gets added to the table.
+ *
+ * The returned table preserves the entry iteration order of the original collection.
+ */
+inline fun <R, C, V, T> Collection<T>.associateTable(transform: (T) -> Entry<R, C, V>): Table<R, C, V> =
+        map(transform).toTable()
+
+/**
+ * Returns a [Table] containing the elements from the given collection indexed by the key
+ * returned from [keySelector] function applied to each element.
+ *
+ * If any two elements would have the same key returned by [keySelector] the last one gets added to the table.
+ */
+inline fun <R, C, V> Collection<V>.associateTableBy(keySelector: (V) -> Pair<R, C>): Table<R, C, V> =
+        associateBy(keySelector).toTable()
+
+/**
+ * Returns a [Table] containing the values provided by [valueTransform] and indexed by [keySelector] functions applied to elements of the given collection.
+ *
+ * If any two elements would have the same key returned by [keySelector] the last one gets added to the table.
+ */
+inline fun <R, C, V, T> Collection<T>.associateTableBy(keySelector: (T) -> Pair<R, C>, valueTransform: (T) -> V): Table<R, C, V> =
+        associateBy(keySelector, valueTransform).toTable()

--- a/src/test/kotlin/kable/CollectionsTest.kt
+++ b/src/test/kotlin/kable/CollectionsTest.kt
@@ -60,4 +60,40 @@ class CollectionsTest {
 
         assertEquals(table, list.groupTableBy({ it.first() to it.length }, String::reversed))
     }
+
+    @Test fun testCreateTableWithAssociate() {
+        val list = listOf("hello world", "goodbye", "bye")
+
+        val table = tableOf(
+                entry('h', 11, false),
+                entry('g', 7, false),
+                entry('b', 3, true)
+        )
+
+        assertEquals(table, list.associateTable { entry(it.first(), it.length, it.length < 4) })
+    }
+
+    @Test fun testCreateTableWithAssociateBy() {
+        val list = listOf("hello world", "goodbye", "bye")
+
+        val table = tableOf(
+                entry('h', 11, "hello world"),
+                entry('g', 7, "goodbye"),
+                entry('b', 3, "bye")
+        )
+
+        assertEquals(table, list.associateTableBy { it.first() to it.length })
+    }
+
+    @Test fun testCreateTableWithAssociateByWithValueTransform() {
+        val list = listOf("hello world", "goodbye", "bye")
+
+        val table = tableOf(
+                entry('h', 11, "dlrow olleh"),
+                entry('g', 7, "eybdoog"),
+                entry('b', 3, "eyb")
+        )
+
+        assertEquals(table, list.associateTableBy({ it.first() to it.length }, String::reversed))
+    }
 }

--- a/src/test/kotlin/kable/CollectionsTest.kt
+++ b/src/test/kotlin/kable/CollectionsTest.kt
@@ -36,4 +36,28 @@ class CollectionsTest {
 
         assertEquals(table, list.toTable())
     }
+
+    @Test fun testCreateTableWithGroupBy() {
+        val list = listOf("hello world", "goodbye", "bye", "bee")
+
+        val table = tableOf(
+                entry('h', 11, listOf("hello world")),
+                entry('g', 7, listOf("goodbye")),
+                entry('b', 3, listOf("bye", "bee"))
+        )
+
+        assertEquals(table, list.groupTableBy { it.first() to it.length })
+    }
+
+    @Test fun testCreateTableWithGroupByWithValueTransform() {
+        val list = listOf("hello world", "goodbye", "bye", "bee")
+
+        val table = tableOf(
+                entry('h', 11, listOf("dlrow olleh")),
+                entry('g', 7, listOf("eybdoog")),
+                entry('b', 3, listOf("eyb", "eeb"))
+        )
+
+        assertEquals(table, list.groupTableBy({ it.first() to it.length }, String::reversed))
+    }
 }


### PR DESCRIPTION
Makes possible to create tables from collections with groupBy and associateBy like we can do for map.